### PR TITLE
Header ordering for Intel MPI: mpi.h must come before stdio.h

### DIFF
--- a/modules/comm/comm.cpp
+++ b/modules/comm/comm.cpp
@@ -31,6 +31,7 @@ Free Software Foundation, Inc.,
 Boston, MA 02111-1307 USA
 */
 
+#include <mpi.h>
 #include <iostream>
 #include <map>
 #include <assert.h>
@@ -39,7 +40,6 @@ Boston, MA 02111-1307 USA
 
 using namespace std;
 
-#include <mpi.h>
 #include <pnmpimod.h>
 
 #include "commsub.h"

--- a/modules/comm/commsub-empty.cpp
+++ b/modules/comm/commsub-empty.cpp
@@ -31,9 +31,9 @@ Free Software Foundation, Inc.,
 Boston, MA 02111-1307 USA
 */
 
+#include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <mpi.h>
 #include "commsub.h"
 
 void COMM_ALL_INIT(int argc, char**argv) 

--- a/modules/comm/commsub-print.cpp
+++ b/modules/comm/commsub-print.cpp
@@ -31,9 +31,9 @@ Free Software Foundation, Inc.,
 Boston, MA 02111-1307 USA
 */
 
+#include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <mpi.h>
 #include "commsub.h"
 
 /*--------------------------------------------------------------------------*/

--- a/modules/datatype/datatype.cpp
+++ b/modules/datatype/datatype.cpp
@@ -31,11 +31,11 @@ Free Software Foundation, Inc.,
 Boston, MA 02111-1307 USA
 */
 
+#include <mpi.h>
 #include <iostream>
 #include <map>
 #include <stdlib.h>
 
-#include <mpi.h>
 #include <pnmpimod.h>
 #include "datatype.h"
 

--- a/modules/requests/requests.cpp
+++ b/modules/requests/requests.cpp
@@ -31,10 +31,10 @@ Free Software Foundation, Inc.,
 Boston, MA 02111-1307 USA
 */
 
+#include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <mpi.h>
 #include <pnmpimod.h>
 #include <status.h>
 #include "requests.h"


### PR DESCRIPTION
Compilation for certain combinations of compiler plus Intel MPI fails, indicating that mpi.h must be included before stdio.h (and friends). Re-ordered the inclusions, tested across gcc, intel, and pgi compilers with openmpi, mvapich2, and intel-mpi libraries (multiple versions each).